### PR TITLE
Fix clippy lints

### DIFF
--- a/src/bin/anglebetweenlines.rs
+++ b/src/bin/anglebetweenlines.rs
@@ -23,13 +23,13 @@ fn find_line(point_a: Point, point_b: Point) -> (i64, i64, i64) {
 }
 
 fn plot_line(image: &mut Image, (a, b, c): (i64, i64, i64)) {
-    let x = if a != 0 { -1 * (c) / a } else { 0 };
+    let x = if a != 0 { -c / a } else { 0 };
     let mut prev_point = (x, 0);
     for y in 0..(WINDOW_HEIGHT as i64) {
         // ax+by+c =0 =>
         // x=(-c-by)/a
 
-        let x = if a != 0 { -1 * (c + b * y) / a } else { 0 };
+        let x = if a != 0 { -(c + b * y) / a } else { 0 };
         let new_point = (x, y);
         image.plot_line_width(prev_point, new_point, 1.0);
         prev_point = new_point;

--- a/src/bin/anglebetweenlines.rs
+++ b/src/bin/anglebetweenlines.rs
@@ -5,7 +5,7 @@ const WINDOW_WIDTH: usize = 300;
 const WINDOW_HEIGHT: usize = 300;
 include!("../bizcat.xbm.rs");
 
-fn find_angle((a1, b1, c1): (i64, i64, i64), (a2, b2, c2): (i64, i64, i64)) -> f64 {
+fn find_angle((a1, b1, _c1): (i64, i64, i64), (a2, b2, _c2): (i64, i64, i64)) -> f64 {
     let nom = (a1 * a2 + b1 * b2) as f64;
     let denom = ((a1 * a1 + b1 * b1) * (a2 * a2 + b2 * b2)) as f64;
 

--- a/src/bin/archimedeanspiral.rs
+++ b/src/bin/archimedeanspiral.rs
@@ -15,7 +15,7 @@ pub fn arch(image: &mut Image, center: Point) {
     let (dx, dy) = center;
     let mut prev_point = center;
     while theta < max_angle {
-        theta = theta + 0.002_f64;
+        theta += 0.002_f64;
 
         let r = a + b * theta;
         let x = (r * theta.cos()) as i64 + dx;

--- a/src/bin/archimedeanspiral.rs
+++ b/src/bin/archimedeanspiral.rs
@@ -1,5 +1,5 @@
 use bitmappers_companion::*;
-use minifb::{CursorStyle, Key, MouseButton, MouseMode, Window, WindowOptions};
+use minifb::{Key, Window, WindowOptions};
 
 const WINDOW_WIDTH: usize = 400;
 const WINDOW_HEIGHT: usize = 400;

--- a/src/bin/beams.rs
+++ b/src/bin/beams.rs
@@ -35,18 +35,18 @@ fn main() {
     image.draw_outline();
 
     /* beam A */
-    let _0 = (40, 23);
-    let _1 = (95, 96);
-    image.plot_line_width((1, 50), _0, 1.0);
-    image.plot_line_width(_0, _1, 1.0);
-    image.plot_line_width((1, 160), _1, 1.0);
+    let b0 = (40, 23);
+    let b1 = (95, 96);
+    image.plot_line_width((1, 50), b0, 1.0);
+    image.plot_line_width(b0, b1, 1.0);
+    image.plot_line_width((1, 160), b1, 1.0);
 
     /* beam B */
-    let _2 = (98, 23);
-    let _3 = (60, 96);
-    image.plot_line_width((150, 50), _2, 1.0);
-    image.plot_line_width(_2, _3, 1.0);
-    image.plot_line_width((150, 148), _3, 1.0);
+    let b2 = (98, 23);
+    let b3 = (60, 96);
+    image.plot_line_width((150, 50), b2, 1.0);
+    image.plot_line_width(b2, b3, 1.0);
+    image.plot_line_width((150, 148), b3, 1.0);
 
     while window.is_open() && !window.is_key_down(Key::Escape) && !window.is_key_down(Key::Q) {
         image.draw(&mut buffer, BLACK, None, WINDOW_WIDTH);

--- a/src/bin/bezier.rs
+++ b/src/bin/bezier.rs
@@ -80,7 +80,7 @@ fn main() {
         image.write_str(
             &bizcat,
             "Click and drag the points!",
-            (1 * WINDOW_WIDTH as i64 / 4, 3 * WINDOW_HEIGHT as i64 / 4),
+            (WINDOW_WIDTH as i64 / 4, 3 * WINDOW_HEIGHT as i64 / 4),
         );
         image.draw(&mut buffer, BLACK, Some(WHITE), WINDOW_WIDTH);
         match &mut state {

--- a/src/bin/bezier.rs
+++ b/src/bin/bezier.rs
@@ -85,7 +85,7 @@ fn main() {
         image.draw(&mut buffer, BLACK, Some(WHITE), WINDOW_WIDTH);
         match &mut state {
             DragMode::Off { selected } => {
-                let mut selected = selected.clone();
+                let mut selected = *selected;
                 if let Some((x, y)) = window.get_mouse_pos(MouseMode::Clamp) {
                     let x = x as i64;
                     let y = y as i64;

--- a/src/bin/bezierglyph.rs
+++ b/src/bin/bezierglyph.rs
@@ -90,47 +90,50 @@ fn main() {
     window.limit_update_rate(Some(std::time::Duration::from_micros(16600)));
 
     let mut image = Image::new(WINDOW_WIDTH, WINDOW_HEIGHT, 0, 0);
-    let mut curves = vec![];
     /*
     /* Construct an I glyph: */
-    curves.push(Bezier::new(vec![(180, 75), (180, 350)]));
-    curves.push(Bezier::new(vec![(130, 65), (166, 60), (180, 75)]));
-    curves.push(Bezier::new(vec![(230, 75), (230, 350)]));
-    curves.push(Bezier::new(vec![(230, 75), (235, 60), (280, 65)]));
-    curves.push(Bezier::new(vec![(280, 50), (130, 50)]));
-    curves.push(Bezier::new(vec![(280, 370), (130, 370)]));
-    curves.push(Bezier::new(vec![(133, 360), (185, 365), (180, 350)]));
-    curves.push(Bezier::new(vec![(230, 350), (230, 365), (280, 360)]));
-    curves.push(Bezier::new(vec![(130, 65), (130, 50)]));
-    curves.push(Bezier::new(vec![(280, 65), (280, 50)]));
-    curves.push(Bezier::new(vec![(130, 360), (130, 370)]));
-    curves.push(Bezier::new(vec![(280, 360), (280, 370)]));
+    let mut curves = vec![
+        Bezier::new(vec![(180, 75), (180, 350)]),
+        Bezier::new(vec![(130, 65), (166, 60), (180, 75)]),
+        Bezier::new(vec![(230, 75), (230, 350)]),
+        Bezier::new(vec![(230, 75), (235, 60), (280, 65)]),
+        Bezier::new(vec![(280, 50), (130, 50)]),
+        Bezier::new(vec![(280, 370), (130, 370)]),
+        Bezier::new(vec![(133, 360), (185, 365), (180, 350)]),
+        Bezier::new(vec![(230, 350), (230, 365), (280, 360)]),
+        Bezier::new(vec![(130, 65), (130, 50)]),
+        Bezier::new(vec![(280, 65), (280, 50)]),
+        Bezier::new(vec![(130, 360), (130, 370)]),
+        Bezier::new(vec![(280, 360), (280, 370)]),
+    ];
     */
     /* Construct an R glyph: */
-    curves.push(Bezier::new(vec![(54, 72), (55, 298)]));
-    curves.push(Bezier::new(vec![(27, 328), (61, 333), (55, 299)]));
-    curves.push(Bezier::new(vec![(26, 328), (27, 338)]));
-    curves.push(Bezier::new(vec![(27, 339), (124, 339)]));
-    curves.push(Bezier::new(vec![(98, 306), (97, 209)]));
-    curves.push(Bezier::new(vec![(97, 301), (98, 334), (123, 330)]));
-    curves.push(Bezier::new(vec![(123, 330), (124, 337)]));
-    curves.push(Bezier::new(vec![(12, 53), (54, 55), (53, 72)]));
-    curves.push(Bezier::new(vec![(11, 52), (174, 53)]));
-    curves.push(Bezier::new(vec![(174, 55), (251, 63), (266, 124)]));
-    curves.push(Bezier::new(vec![(183, 192), (265, 182), (266, 127)]));
-    curves.push(Bezier::new(vec![(100, 180), (101, 78)]));
-    curves.push(Bezier::new(vec![(100, 79), (125, 78)]));
-    curves.push(Bezier::new(vec![(126, 79), (209, 67), (216, 120)]));
-    curves.push(Bezier::new(vec![(136, 177), (217, 178), (218, 122)]));
-    curves.push(Bezier::new(vec![(105, 176), (135, 176)]));
-    curves.push(Bezier::new(vec![(96, 209), (138, 209)]));
-    curves.push(Bezier::new(vec![(140, 210), (183, 201), (203, 243)]));
-    curves.push(Bezier::new(vec![(205, 245), (215, 296), (241, 327)]));
-    curves.push(Bezier::new(vec![(187, 192), (244, 197), (252, 237)]));
-    curves.push(Bezier::new(vec![(253, 241), (263, 304), (290, 317)]));
-    curves.push(Bezier::new(vec![(241, 327), (287, 359), (339, 301)]));
-    curves.push(Bezier::new(vec![(292, 317), (316, 318), (332, 294)]));
-    curves.push(Bezier::new(vec![(335, 295), (339, 303)]));
+    let mut curves = vec![
+        Bezier::new(vec![(54, 72), (55, 298)]),
+        Bezier::new(vec![(27, 328), (61, 333), (55, 299)]),
+        Bezier::new(vec![(26, 328), (27, 338)]),
+        Bezier::new(vec![(27, 339), (124, 339)]),
+        Bezier::new(vec![(98, 306), (97, 209)]),
+        Bezier::new(vec![(97, 301), (98, 334), (123, 330)]),
+        Bezier::new(vec![(123, 330), (124, 337)]),
+        Bezier::new(vec![(12, 53), (54, 55), (53, 72)]),
+        Bezier::new(vec![(11, 52), (174, 53)]),
+        Bezier::new(vec![(174, 55), (251, 63), (266, 124)]),
+        Bezier::new(vec![(183, 192), (265, 182), (266, 127)]),
+        Bezier::new(vec![(100, 180), (101, 78)]),
+        Bezier::new(vec![(100, 79), (125, 78)]),
+        Bezier::new(vec![(126, 79), (209, 67), (216, 120)]),
+        Bezier::new(vec![(136, 177), (217, 178), (218, 122)]),
+        Bezier::new(vec![(105, 176), (135, 176)]),
+        Bezier::new(vec![(96, 209), (138, 209)]),
+        Bezier::new(vec![(140, 210), (183, 201), (203, 243)]),
+        Bezier::new(vec![(205, 245), (215, 296), (241, 327)]),
+        Bezier::new(vec![(187, 192), (244, 197), (252, 237)]),
+        Bezier::new(vec![(253, 241), (263, 304), (290, 317)]),
+        Bezier::new(vec![(241, 327), (287, 359), (339, 301)]),
+        Bezier::new(vec![(292, 317), (316, 318), (332, 294)]),
+        Bezier::new(vec![(335, 295), (339, 303)]),
+    ];
     enum DragMode {
         Off { selected: Option<usize> },
         On { b: usize, i: usize, x: i64, y: i64 },

--- a/src/bin/bezierglyph.rs
+++ b/src/bin/bezierglyph.rs
@@ -173,7 +173,7 @@ fn main() {
         }
         match &mut state {
             DragMode::Off { selected } => {
-                let mut selected = selected.clone();
+                let mut selected = *selected;
                 if let Some((x, y)) = window.get_mouse_pos(MouseMode::Clamp) {
                     let x = x as i64;
                     let y = y as i64;

--- a/src/bin/bezierweights.rs
+++ b/src/bin/bezierweights.rs
@@ -103,7 +103,7 @@ fn main() {
         image.write_str(
             &bizcat,
             "Click and drag the points!",
-            (1 * WINDOW_WIDTH as i64 / 4, 3 * WINDOW_HEIGHT as i64 / 4),
+            (WINDOW_WIDTH as i64 / 4, 3 * WINDOW_HEIGHT as i64 / 4),
         );
         image.draw(&mut buffer, BLACK, Some(WHITE), WINDOW_WIDTH);
         match &mut state {

--- a/src/bin/bezierweights.rs
+++ b/src/bin/bezierweights.rs
@@ -108,7 +108,7 @@ fn main() {
         image.draw(&mut buffer, BLACK, Some(WHITE), WINDOW_WIDTH);
         match &mut state {
             DragMode::Off { selected } => {
-                let mut selected = selected.clone();
+                let mut selected = *selected;
                 if let Some((x, y)) = window.get_mouse_pos(MouseMode::Clamp) {
                     let x = x as i64;
                     let y = y as i64;

--- a/src/bin/boundingcircle.rs
+++ b/src/bin/boundingcircle.rs
@@ -103,7 +103,7 @@ fn min_circle_w_point(points: &[Point], q: Point) -> Circle {
 }
 
 fn min_circle_w_points(points: &[Point], q1: Point, q2: Point) -> Circle {
-    let mut points = points.to_vec();
+    let points = points.to_vec();
 
     let d_0 = (
         (((q1.0 + q2.0) / 2), (q1.1 + q2.1) / 2),

--- a/src/bin/boundingcircle.rs
+++ b/src/bin/boundingcircle.rs
@@ -110,6 +110,7 @@ fn min_circle_w_points(points: &[Point], q1: Point, q2: Point) -> Circle {
     );
 
     let mut d_prev = d_0;
+    #[allow(clippy::needless_range_loop)]
     for k in 0..points.len() {
         //image.plot_circle((d_prev.0.0+45, d_prev.0.1+45), d_prev.1 as _, 0.);
         let p_k = points[k];

--- a/src/bin/boundingcircle.rs
+++ b/src/bin/boundingcircle.rs
@@ -163,13 +163,14 @@ fn min_circle_w_3_points(q1: Point, q2: Point, q3: Point) -> Circle {
     let c1 = c1 as i64;
     let c2 = c2 as i64;
     let c3 = c3 as i64;
-    return (
+
+    (
         (
             ((c2 + c3) * q1.0 + (c3 + c1) * q2.0 + (c1 + c2) * q3.0) / ((2. * c) as i64),
             ((c2 + c3) * q1.1 + (c3 + c1) * q2.1 + (c1 + c2) * q3.1) / ((2. * c) as i64),
         ),
         f64::sqrt((d_1 + d_2) * (d_2 + d_3) * (d_3 + d_1) / (4. * c)),
-    );
+    )
 }
 
 fn main() {

--- a/src/bin/boundingcircle.rs
+++ b/src/bin/boundingcircle.rs
@@ -156,9 +156,9 @@ fn min_circle_w_3_points(q1: Point, q2: Point, q3: Point) -> Circle {
     let d_2 = q13 * q12;
     let d_3 = q13 * q23;
 
-    let c1 = (d_2 * d_3);
-    let c2 = (d_3 * d_1);
-    let c3 = (d_1 * d_2);
+    let c1 = d_2 * d_3;
+    let c2 = d_3 * d_1;
+    let c3 = d_1 * d_2;
     let c = c1 + c2 + c3;
     let c1 = c1 as i64;
     let c2 = c2 as i64;

--- a/src/bin/boundingcircle.rs
+++ b/src/bin/boundingcircle.rs
@@ -2,7 +2,6 @@ use bitmappers_companion::*;
 use minifb::{Key, Window, WindowOptions};
 use rand::seq::SliceRandom;
 use rand::thread_rng;
-use std::f64::consts::{FRAC_PI_2, PI};
 
 include!("../me.xbm.rs");
 

--- a/src/bin/bresenham.rs
+++ b/src/bin/bresenham.rs
@@ -66,11 +66,11 @@ pub fn plot_line_width(_self: &mut Image, (x1, y1): (i64, i64), (x2, y2): (i64, 
                 return;
             }
             if d >= 0 {
-                y = y + sy;
-                d = d - ax;
+                y += sy;
+                d -= ax;
             }
-            x = x + sx;
-            d = d + ay;
+            x += sx;
+            d += ay;
         }
     } else {
         d = ax - ay / 2;
@@ -102,11 +102,11 @@ pub fn plot_line_width(_self: &mut Image, (x1, y1): (i64, i64), (x2, y2): (i64, 
                 return;
             }
             if d >= 0 {
-                x = x + sx;
-                d = d - ay;
+                x += sx;
+                d -= ay;
             }
-            y = y + sy;
-            d = d + ax;
+            y += sy;
+            d += ax;
         }
     }
 }

--- a/src/bin/bresenham.rs
+++ b/src/bin/bresenham.rs
@@ -140,10 +140,10 @@ fn main() {
     let point_l = (50, 0);
 
     println!("r = {}", distance_between_two_points(point_k, point_l));
-    let point_k = (5, 23 - 15);
-    let point_l = (45, 36 - 15);
-    let point_k = (4, 45 - 15);
-    let point_l = (44, 16 - 15);
+    let _point_k = (5, 23 - 15);
+    let _point_l = (45, 36 - 15);
+    let _point_k = (4, 45 - 15);
+    let _point_l = (44, 16 - 15);
     let point_k = (45 - 15, 4);
     let point_l = (45 - 15, 45);
     plot_line_width(&mut image, point_k, point_l, 5.0);

--- a/src/bin/bresenham.rs
+++ b/src/bin/bresenham.rs
@@ -46,7 +46,7 @@ pub fn plot_line_width(_self: &mut Image, (x1, y1): (i64, i64), (x2, y2): (i64, 
                 let mut _x = x;
                 loop {
                     let t = total(_x);
-                    if t < -1 * delta || t > delta {
+                    if t < -delta || t > delta {
                         break;
                     }
                     _x += 1;
@@ -55,7 +55,7 @@ pub fn plot_line_width(_self: &mut Image, (x1, y1): (i64, i64), (x2, y2): (i64, 
                 let mut _x = x;
                 loop {
                     let t = total(_x);
-                    if t < -1 * delta || t > delta {
+                    if t < -delta || t > delta {
                         break;
                     }
                     _x -= 1;
@@ -82,7 +82,7 @@ pub fn plot_line_width(_self: &mut Image, (x1, y1): (i64, i64), (x2, y2): (i64, 
                 let mut _x = x;
                 loop {
                     let t = total(_x);
-                    if t < -1 * delta || t > delta {
+                    if t < -delta || t > delta {
                         break;
                     }
                     _x += 1;
@@ -91,7 +91,7 @@ pub fn plot_line_width(_self: &mut Image, (x1, y1): (i64, i64), (x2, y2): (i64, 
                 let mut _x = x;
                 loop {
                     let t = total(_x);
-                    if t < -1 * delta || t > delta {
+                    if t < -delta || t > delta {
                         break;
                     }
                     _x -= 1;

--- a/src/bin/equidistant.rs
+++ b/src/bin/equidistant.rs
@@ -16,20 +16,20 @@ fn find_equidistant(point_a: Point, point_b: Point) -> (i64, i64, i64) {
     //assert_eq!(al*midpoint.0+bl*midpoint.1, -cl);
 
     let a = bl;
-    let b = -1 * al;
+    let b = -al;
     let c = (al * midpoint.1) - (bl * midpoint.0);
 
     (a, b, c)
 }
 
 fn plot_line(image: &mut Image, (a, b, c): (i64, i64, i64)) {
-    let x = if a != 0 { -1 * (c) / a } else { 0 };
+    let x = if a != 0 { -c / a } else { 0 };
     let mut prev_point = (x, 0);
     for y in 0..(WINDOW_HEIGHT as i64) {
         // ax+by+c =0 =>
         // x=(-c-by)/a
 
-        let x = if a != 0 { -1 * (c + b * y) / a } else { 0 };
+        let x = if a != 0 { -(c + b * y) / a } else { 0 };
         let new_point = (x, y);
         image.plot_line_width(prev_point, new_point, 1.0);
         prev_point = new_point;

--- a/src/bin/flowsnake.rs
+++ b/src/bin/flowsnake.rs
@@ -40,7 +40,6 @@ fn gosper(img: &mut Image, x_offset: i64, y_offset: i64, order: usize, step_size
     let mut stack = VecDeque::from(a_production(order));
 
     let mut angle: Decimal = -Decimal::HALF_PI;
-    let step_size: Decimal = Decimal::from(step_size);
 
     let sixty_degrees: Decimal = Decimal::from_str("1.047197551196597746154214").unwrap();
 

--- a/src/bin/hilbert.rs
+++ b/src/bin/hilbert.rs
@@ -1,6 +1,5 @@
 use bitmappers_companion::*;
 use minifb::{Key, Window, WindowOptions};
-use std::f64::consts::FRAC_PI_2;
 
 const WINDOW_WIDTH: usize = 200;
 const WINDOW_HEIGHT: usize = 200;

--- a/src/bin/lineintersection.rs
+++ b/src/bin/lineintersection.rs
@@ -25,13 +25,13 @@ fn find_line(point_a: Point, point_b: Point) -> (i64, i64, i64) {
 }
 
 fn plot_line(image: &mut Image, (a, b, c): (i64, i64, i64)) {
-    let x = if a != 0 { -1 * (c) / a } else { 0 };
+    let x = if a != 0 { -c / a } else { 0 };
     let mut prev_point = (x, 0);
     for y in 0..(WINDOW_HEIGHT as i64) {
         // ax+by+c =0 =>
         // x=(-c-by)/a
 
-        let x = if a != 0 { -1 * (c + b * y) / a } else { 0 };
+        let x = if a != 0 { -(c + b * y) / a } else { 0 };
         let new_point = (x, y);
         image.plot_line_width(prev_point, new_point, 1.0);
         prev_point = new_point;

--- a/src/bin/mirror.rs
+++ b/src/bin/mirror.rs
@@ -18,13 +18,13 @@ fn find_mirror(point: Point, l: Line) -> Point {
 }
 
 fn plot_line(image: &mut Image, (a, b, c): (i64, i64, i64)) {
-    let x = if a != 0 { -1 * (c) / a } else { 0 };
+    let x = if a != 0 { -c / a } else { 0 };
     let mut prev_point = (x, 0);
     for y in 0..(WINDOW_HEIGHT as i64) {
         // ax+by+c =0 =>
         // x=(-c-by)/a
 
-        let x = if a != 0 { -1 * (c + b * y) / a } else { 0 };
+        let x = if a != 0 { -(c + b * y) / a } else { 0 };
         let new_point = (x, y);
         image.plot_line_width(prev_point, new_point, 1.0);
         prev_point = new_point;

--- a/src/bin/mirror.rs
+++ b/src/bin/mirror.rs
@@ -52,7 +52,7 @@ fn main() {
     window.limit_update_rate(Some(std::time::Duration::from_micros(16600)));
 
     let mut p_m = (35, 35);
-    let p_n = (128, 250);
+    let _p_n = (128, 250);
     let l = (-57, 174, -19470);
 
     let mut image = Image::new(WINDOW_WIDTH, WINDOW_WIDTH, 0, 0);

--- a/src/bin/mirror.rs
+++ b/src/bin/mirror.rs
@@ -52,7 +52,7 @@ fn main() {
     window.limit_update_rate(Some(std::time::Duration::from_micros(16600)));
 
     let mut p_m = (35, 35);
-    let mut p_n = (128, 250);
+    let p_n = (128, 250);
     let l = (-57, 174, -19470);
 
     let mut image = Image::new(WINDOW_WIDTH, WINDOW_WIDTH, 0, 0);

--- a/src/bin/rotation.rs
+++ b/src/bin/rotation.rs
@@ -1,6 +1,5 @@
 use bitmappers_companion::*;
 use minifb::{Key, Window, WindowOptions};
-use std::f64::consts::FRAC_PI_2;
 
 pub fn bits_to_bytes(bits: &[u8], width: usize) -> Vec<u32> {
     let mut ret = Vec::with_capacity(bits.len() * 8);

--- a/src/bin/roundcorner.rs
+++ b/src/bin/roundcorner.rs
@@ -15,7 +15,7 @@ pub fn distance_line_to_point((x, y): Point, (a, b, c): Line) -> f64 {
     }
 }
 
-fn find_angle((a1, b1, _c1): (i64, i64, i64), (a2, b2, _c2): (i64, i64, i64)) -> f64 {
+fn _find_angle((a1, b1, _c1): (i64, i64, i64), (a2, b2, _c2): (i64, i64, i64)) -> f64 {
     let nom = (a1 * a2 + b1 * b2) as f64;
     let denom = ((a1 * a1 + b1 * b1) * (a2 * a2 + b2 * b2)) as f64;
 
@@ -32,7 +32,7 @@ fn find_line(point_a: Point, point_b: Point) -> (i64, i64, i64) {
     (a, b, c)
 }
 
-fn find_intersection((a1, b1, c1): (i64, i64, i64), (a2, b2, c2): (i64, i64, i64)) -> Point {
+fn _find_intersection((a1, b1, c1): (i64, i64, i64), (a2, b2, c2): (i64, i64, i64)) -> Point {
     let denom = a1 * b2 - a2 * b1;
 
     if denom == 0 {
@@ -42,7 +42,7 @@ fn find_intersection((a1, b1, c1): (i64, i64, i64), (a2, b2, c2): (i64, i64, i64
     ((b1 * c2 - b2 * c1) / denom, (a2 * c1 - a1 * c2) / denom)
 }
 
-fn plot_line(image: &mut Image, (a, b, c): (i64, i64, i64)) {
+fn _plot_line(image: &mut Image, (a, b, c): (i64, i64, i64)) {
     let x = if a != 0 { -c / a } else { 0 };
     let mut prev_point = (x, 0);
     for y in 0..(WINDOW_HEIGHT as i64) {
@@ -57,7 +57,7 @@ fn plot_line(image: &mut Image, (a, b, c): (i64, i64, i64)) {
     }
 }
 
-fn perpendicular((a, b, _c): (i64, i64, i64), p: Point) -> (i64, i64, i64) {
+fn _perpendicular((a, b, _c): (i64, i64, i64), p: Point) -> (i64, i64, i64) {
     (b, -a, a * p.1 - b * p.0)
 }
 
@@ -73,7 +73,7 @@ fn point_perpendicular((a, b, c): Line, p: Point) -> Point {
     )
 }
 
-fn arctan2(x: i64, y: i64) -> f64 {
+fn _arctan2(x: i64, y: i64) -> f64 {
     let mut r = 0.;
     if y.abs() < x.abs() {
         if x != 0 {

--- a/src/bin/roundcorner.rs
+++ b/src/bin/roundcorner.rs
@@ -139,8 +139,8 @@ fn draw_arc(image: &mut Image, p: Point, r: f64, startangle: f64, angle: f64) {
 
 fn round_corner(
     image: &mut Image,
-    (mut p1, mut p2): (Point, Point),
-    (mut p3, mut p4): (Point, Point),
+    (p1, mut p2): (Point, Point),
+    (mut p3, p4): (Point, Point),
 ) {
     const R: f64 = 20.;
 

--- a/src/bin/roundcorner.rs
+++ b/src/bin/roundcorner.rs
@@ -84,17 +84,15 @@ fn arctan2(x: i64, y: i64) -> f64 {
                 r += 2. * std::f64::consts::PI;
             }
         }
-    } else {
-        if y != 0 {
-            r = f64::atan(x as f64 / y as f64);
-            if y > 0 {
-                r = std::f64::consts::FRAC_PI_2 - r;
-            } else {
-                r = 3. * std::f64::consts::FRAC_PI_2 - r;
-            }
+    } else if y != 0 {
+        r = f64::atan(x as f64 / y as f64);
+        if y > 0 {
+            r = std::f64::consts::FRAC_PI_2 - r;
         } else {
-            r = std::f64::consts::FRAC_PI_2;
+            r = 3. * std::f64::consts::FRAC_PI_2 - r;
         }
+    } else {
+        r = std::f64::consts::FRAC_PI_2;
     }
     r
 }

--- a/src/bin/roundcorner.rs
+++ b/src/bin/roundcorner.rs
@@ -15,7 +15,7 @@ pub fn distance_line_to_point((x, y): Point, (a, b, c): Line) -> f64 {
     }
 }
 
-fn find_angle((a1, b1, c1): (i64, i64, i64), (a2, b2, c2): (i64, i64, i64)) -> f64 {
+fn find_angle((a1, b1, _c1): (i64, i64, i64), (a2, b2, _c2): (i64, i64, i64)) -> f64 {
     let nom = (a1 * a2 + b1 * b2) as f64;
     let denom = ((a1 * a1 + b1 * b1) * (a2 * a2 + b2 * b2)) as f64;
 
@@ -57,7 +57,7 @@ fn plot_line(image: &mut Image, (a, b, c): (i64, i64, i64)) {
     }
 }
 
-fn perpendicular((a, b, c): (i64, i64, i64), p: Point) -> (i64, i64, i64) {
+fn perpendicular((a, b, _c): (i64, i64, i64), p: Point) -> (i64, i64, i64) {
     (b, -a, a * p.1 - b * p.0)
 }
 
@@ -145,8 +145,8 @@ fn round_corner(
     let l1 = find_line(p1, p2);
     let l2 = find_line(p3, p4);
 
-    let (a1, b1, c1) = l1;
-    let (a2, b2, c2) = l2;
+    let (a1, b1, _c1) = l1;
+    let (a2, b2, _c2) = l2;
 
     let m1 = ((p1.0 + p2.0) / 2, (p1.1 + p2.1) / 2);
     let m2 = ((p3.0 + p4.0) / 2, (p3.1 + p4.1) / 2);
@@ -213,7 +213,7 @@ fn round_corner(
 fn main() {
     let mut bizcat = Image::new(BIZCAT_WIDTH, BIZCAT_HEIGHT, 0, 0);
     bizcat.bytes = bits_to_bytes(BIZCAT_BITS, BIZCAT_WIDTH);
-    let bizcat = BitmapFont::new(bizcat, (8, 16), 0, 0);
+    let _bizcat = BitmapFont::new(bizcat, (8, 16), 0, 0);
 
     let mut buffer: Vec<u32> = vec![WHITE; WINDOW_WIDTH * WINDOW_HEIGHT];
     let mut window = Window::new(

--- a/src/bin/roundcorner.rs
+++ b/src/bin/roundcorner.rs
@@ -43,13 +43,13 @@ fn find_intersection((a1, b1, c1): (i64, i64, i64), (a2, b2, c2): (i64, i64, i64
 }
 
 fn plot_line(image: &mut Image, (a, b, c): (i64, i64, i64)) {
-    let x = if a != 0 { -1 * (c) / a } else { 0 };
+    let x = if a != 0 { -c / a } else { 0 };
     let mut prev_point = (x, 0);
     for y in 0..(WINDOW_HEIGHT as i64) {
         // ax+by+c =0 =>
         // x=(-c-by)/a
 
-        let x = if a != 0 { -1 * (c + b * y) / a } else { 0 };
+        let x = if a != 0 { -(c + b * y) / a } else { 0 };
         let new_point = (x, y);
         image.plot_line_width(prev_point, new_point, 1.0);
         prev_point = new_point;
@@ -58,7 +58,7 @@ fn plot_line(image: &mut Image, (a, b, c): (i64, i64, i64)) {
 }
 
 fn perpendicular((a, b, c): (i64, i64, i64), p: Point) -> (i64, i64, i64) {
-    (b, -1 * a, a * p.1 - b * p.0)
+    (b, -a, a * p.1 - b * p.0)
 }
 
 fn point_perpendicular((a, b, c): Line, p: Point) -> Point {

--- a/src/bin/roundcorner.rs
+++ b/src/bin/roundcorner.rs
@@ -79,9 +79,9 @@ fn arctan2(x: i64, y: i64) -> f64 {
         if x != 0 {
             r = f64::atan(y as f64 / x as f64);
             if x < 0 {
-                r = r + std::f64::consts::PI;
+                r += std::f64::consts::PI;
             } else if y < 0 {
-                r = r + 2. * std::f64::consts::PI;
+                r += 2. * std::f64::consts::PI;
             }
         }
     } else {

--- a/src/bin/shearing.rs
+++ b/src/bin/shearing.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use bitmappers_companion::*;
 use minifb::{Key, Window, WindowOptions};
 

--- a/src/bin/shearing.rs
+++ b/src/bin/shearing.rs
@@ -1,6 +1,5 @@
 use bitmappers_companion::*;
 use minifb::{Key, Window, WindowOptions};
-use std::f64::consts::FRAC_PI_2;
 
 pub fn bits_to_bytes(bits: &[u8], width: usize) -> Vec<u32> {
     let mut ret = Vec::with_capacity(bits.len() * 8);

--- a/src/bin/smooth_scale.rs
+++ b/src/bin/smooth_scale.rs
@@ -26,7 +26,6 @@ use RuleTile::*;
 type Rule<const D: usize> = [[RuleTile; D]; D];
 
 fn matches<const D: usize>(_self: &Rule<D>, buffer: &Image, (x, y): (i64, i64)) -> bool {
-    let ret = true;
     for (row, tilerow) in _self.iter().enumerate() {
         let row = row as i64;
 
@@ -130,7 +129,7 @@ fn smooth<const D: usize>(_self: &Rule<D>, rule_idx: usize, orig: &Image, buffer
                     buffer.plot_line_width(a, b, 1.);
                     buffer.plot_line_width(b, c, 1.);
                     buffer.plot_line_width(c, a, 1.);
-                    let centroid = ((a.0 + b.0 + c.0) / 3, (a.1 + b.1 + c.1) / 3);
+                    let _centroid = ((a.0 + b.0 + c.0) / 3, (a.1 + b.1 + c.1) / 3);
                     buffer.fill_triangle(a, b, c);
                 }
                 //for row in 0..scale_down {
@@ -280,10 +279,10 @@ fn main() {
     for (i, rul) in rule_1_set.iter().enumerate() {
         smooth(rul, i, &original, &mut scaled);
     }
-    for (i, rul) in rule_2_set.iter().enumerate() {
+    for (_i, _rul) in rule_2_set.iter().enumerate() {
         //smooth(&rul, i, &original, &mut scaled);
     }
-    for (i, rul) in rule_3_set.iter().enumerate() {
+    for (_i, _rul) in rule_3_set.iter().enumerate() {
         //smooth(&rul, i, &original, &mut scaled);
     }
     scaled.draw(&mut buffer, BLACK, None, WINDOW_WIDTH);

--- a/src/bin/smooth_scale.rs
+++ b/src/bin/smooth_scale.rs
@@ -28,7 +28,7 @@ type Rule<const D: usize> = [[RuleTile; D]; D];
 fn matches<const D: usize>(_self: &Rule<D>, buffer: &Image, (x, y): (i64, i64)) -> bool {
     let mut row = 0;
     let mut col = 0;
-    let mut ret = true;
+    let ret = true;
     for tilerow in _self {
         for tile in tilerow {
             if *tile as u8 != Ignore as u8 && buffer.get(x + col, y + row).is_none() {
@@ -258,7 +258,7 @@ fn main() {
     // Limit to max ~60 fps update rate
     window.limit_update_rate(Some(std::time::Duration::from_micros(16600)));
 
-    let mut original = Image::from_xbm("./testimages/xface.xbm", 100, 100).unwrap();
+    let original = Image::from_xbm("./testimages/xface.xbm", 100, 100).unwrap();
     original.draw(&mut buffer, BLACK, None, WINDOW_WIDTH);
 
     let mut scaled = Image::new(original.width * 8, original.width * 8, 0, 100);

--- a/src/bin/smooth_scale.rs
+++ b/src/bin/smooth_scale.rs
@@ -79,7 +79,7 @@ fn smooth<const D: usize>(_self: &Rule<D>, rule_idx: usize, orig: &Image, buffer
     std::dbg!(is_reflection);
     while y < og_height {
         while x < og_width {
-            if matches(&_self, &orig, (x, y)) {
+            if matches(_self, orig, (x, y)) {
                 let (dx, dy) = (scale_down * x, scale_down * y);
                 let region_width = scale_down * (D as i64);
                 std::dbg!(region_width);
@@ -289,7 +289,7 @@ fn main() {
     scaled.x_offset += 380;
 
     for (i, rul) in rule_1_set.iter().enumerate() {
-        smooth(&rul, i, &original, &mut scaled);
+        smooth(rul, i, &original, &mut scaled);
     }
     for (i, rul) in rule_2_set.iter().enumerate() {
         //smooth(&rul, i, &original, &mut scaled);

--- a/src/bin/smooth_scale.rs
+++ b/src/bin/smooth_scale.rs
@@ -127,7 +127,7 @@ fn smooth<const D: usize>(_self: &Rule<D>, rule_idx: usize, orig: &Image, buffer
                 c.0 -= 1;
                 c.1 -= 1;
 
-                if !(which_triangle == 2 && !is_reflection) {
+                if which_triangle != 2 || is_reflection {
                     buffer.plot_line_width(a, b, 1.);
                     buffer.plot_line_width(b, c, 1.);
                     buffer.plot_line_width(c, a, 1.);

--- a/src/bin/smooth_scale.rs
+++ b/src/bin/smooth_scale.rs
@@ -236,9 +236,9 @@ fn main() {
             for el in row {
                 print!("{:?}", el as u8);
             }
-            println!("");
+            println!();
         }
-        println!("");
+        println!();
     }
     let mut buffer: Vec<u32> = vec![WHITE; WINDOW_WIDTH * WINDOW_HEIGHT];
     let mut window = Window::new(

--- a/src/bin/smooth_scale.rs
+++ b/src/bin/smooth_scale.rs
@@ -26,11 +26,13 @@ use RuleTile::*;
 type Rule<const D: usize> = [[RuleTile; D]; D];
 
 fn matches<const D: usize>(_self: &Rule<D>, buffer: &Image, (x, y): (i64, i64)) -> bool {
-    let mut row = 0;
-    let mut col = 0;
     let ret = true;
-    for tilerow in _self {
-        for tile in tilerow {
+    for (row, tilerow) in _self.iter().enumerate() {
+        let row = row as i64;
+
+        for (col, tile) in tilerow.iter().enumerate() {
+            let col = col as i64;
+
             if *tile as u8 != Ignore as u8 && buffer.get(x + col, y + row).is_none() {
                 return false;
             }
@@ -47,10 +49,7 @@ fn matches<const D: usize>(_self: &Rule<D>, buffer: &Image, (x, y): (i64, i64)) 
                 }
                 Blank | Filled | Ignore => {}
             }
-            col += 1;
         }
-        col = 0;
-        row += 1;
     }
     true
 }
@@ -177,28 +176,18 @@ fn gen_ruleset<const D: usize>(rule: Rule<D>) -> [Rule<D>; 8] {
     {
         let e = 1;
         let eo = e - 1;
-        let mut row = 0;
-        let mut col = 0;
-        for y in 0..D {
-            for x in (0..D).rev() {
+        for (row, y) in (0..D).enumerate() {
+            for (col, x) in (0..D).rev().enumerate() {
                 ret[e][row][col] = ret[eo][y][x];
-                col += 1;
             }
-            col = 0;
-            row += 1;
         }
     }
     for e in 2..4 {
         let eo = e - 2;
-        let mut row = 0;
-        let mut col = 0;
-        for y in (0..D).rev() {
-            for x in 0..D {
+        for (row, y) in (0..D).rev().enumerate() {
+            for (col, x) in (0..D).enumerate() {
                 ret[e][row][col] = ret[eo][y][x];
-                col += 1;
             }
-            col = 0;
-            row += 1;
         }
     }
     for e in 4..8 {

--- a/src/bin/smooth_scale.rs
+++ b/src/bin/smooth_scale.rs
@@ -129,7 +129,6 @@ fn smooth<const D: usize>(_self: &Rule<D>, rule_idx: usize, orig: &Image, buffer
                     buffer.plot_line_width(a, b, 1.);
                     buffer.plot_line_width(b, c, 1.);
                     buffer.plot_line_width(c, a, 1.);
-                    let _centroid = ((a.0 + b.0 + c.0) / 3, (a.1 + b.1 + c.1) / 3);
                     buffer.fill_triangle(a, b, c);
                 }
                 //for row in 0..scale_down {
@@ -218,7 +217,7 @@ fn gen_ruleset<const D: usize>(rule: Rule<D>) -> [Rule<D>; 8] {
 fn main() {
     let rule_1_set: [Rule<3>; 8] = gen_ruleset(RULE_1);
     let rule_2_set: [Rule<4>; 8] = gen_ruleset(RULE_2);
-    let rule_3_set: [Rule<5>; 8] = gen_ruleset(RULE_3);
+    let _rule_3_set: [Rule<5>; 8] = gen_ruleset(RULE_3);
     for rul in rule_2_set {
         for row in rul {
             for el in row {
@@ -279,12 +278,14 @@ fn main() {
     for (i, rul) in rule_1_set.iter().enumerate() {
         smooth(rul, i, &original, &mut scaled);
     }
-    for (_i, _rul) in rule_2_set.iter().enumerate() {
-        //smooth(&rul, i, &original, &mut scaled);
+    /*
+    for (i, rul) in rule_2_set.iter().enumerate() {
+        smooth(&rul, i, &original, &mut scaled);
     }
-    for (_i, _rul) in rule_3_set.iter().enumerate() {
-        //smooth(&rul, i, &original, &mut scaled);
+    for (i, rul) in rule_3_set.iter().enumerate() {
+        smooth(&rul, i, &original, &mut scaled);
     }
+    */
     scaled.draw(&mut buffer, BLACK, None, WINDOW_WIDTH);
 
     while window.is_open() && !window.is_key_down(Key::Escape) && !window.is_key_down(Key::Q) {

--- a/src/bin/squircle.rs
+++ b/src/bin/squircle.rs
@@ -39,8 +39,7 @@ pub fn plot_squircle(
     }
     for i in (2 * r)..(4 * r + 1) {
         let x: i64 = (3 * r - i) + w;
-        let y = -1
-            * (((r as f64).powi(n) - ((3 * r - i) as f64).abs().powi(n)).powf(1. / n as f64))
+        let y = -(((r as f64).powi(n) - ((3 * r - i) as f64).abs().powi(n)).powf(1. / n as f64))
                 as i64
             + h;
         image.plot_line_width(prev_pos, (xm - x as i64, ym - y), _wd);

--- a/src/bin/truchet.rs
+++ b/src/bin/truchet.rs
@@ -2,8 +2,6 @@ use bitmappers_companion::*;
 use minifb::{Key, Window, WindowOptions};
 use rand::seq::SliceRandom;
 use rand::thread_rng;
-use rust_decimal::prelude::*;
-use std::collections::VecDeque;
 
 const WINDOW_WIDTH: usize = 1000;
 const WINDOW_HEIGHT: usize = 1000;

--- a/src/bin/xbmtors.rs
+++ b/src/bin/xbmtors.rs
@@ -1,4 +1,3 @@
-use regex;
 use regex::Regex;
 use std::fs::File;
 use std::io::prelude::*;

--- a/src/bin/zcurve.rs
+++ b/src/bin/zcurve.rs
@@ -11,6 +11,9 @@ fn zcurve(img: &mut Image, x_offset: i64, y_offset: i64) {
     let mut b: u64 = 0;
 
     let mut prev_pos = (sx + x_offset, sy + y_offset);
+
+    // allow for readability, since the bit pattern in the zcurve is 3 bits long
+    #[allow(clippy::unusual_byte_groupings)]
     loop {
         let next = b + 1;
         sx = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,7 +657,7 @@ pub fn distance_line_to_point((x, y): Point, (a, b, c): Line) -> f64 {
     }
 }
 
-pub fn perpendicular((a, b, c): Line, p: Point) -> Line {
+pub fn perpendicular((a, b, _c): Line, p: Point) -> Line {
     (b, -a, a * p.1 - b * p.0)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,11 +341,11 @@ impl Image {
                     return;
                 }
                 if d >= 0 {
-                    y = y + sy;
-                    d = d - ax;
+                    y += sy;
+                    d -= ax;
                 }
-                x = x + sx;
-                d = d + ay;
+                x += sx;
+                d += ay;
             }
         } else {
             /* y step */
@@ -383,11 +383,11 @@ impl Image {
                     return;
                 }
                 if d >= 0 {
-                    x = x + sx;
-                    d = d - ay;
+                    x += sx;
+                    d -= ay;
                 }
-                y = y + sy;
-                d = d + ax;
+                y += sy;
+                d += ax;
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use regex;
 use regex::Regex;
 use std::collections::VecDeque;
 use std::fs::File;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -617,7 +617,7 @@ impl BitmapFont {
         y_offset: usize,
     ) -> Self {
         Self {
-            image: image,
+            image,
             x_offset,
             y_offset,
             glyph_width,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,7 @@ impl Image {
                     let mut _x = x;
                     loop {
                         let t = total(_x);
-                        if t < -1 * delta || t >= delta {
+                        if t < -delta || t >= delta {
                             break;
                         }
                         _x += 1;
@@ -330,7 +330,7 @@ impl Image {
                     let mut _x = x;
                     loop {
                         let t = total(_x);
-                        if t < -1 * delta || t >= delta {
+                        if t < -delta || t >= delta {
                             break;
                         }
                         _x -= 1;
@@ -363,7 +363,7 @@ impl Image {
                     let mut _x = x;
                     loop {
                         let t = total(_x);
-                        if t < -1 * delta || t >= delta {
+                        if t < -delta || t >= delta {
                             break;
                         }
                         _x += 1;
@@ -372,7 +372,7 @@ impl Image {
                     let mut _x = x;
                     loop {
                         let t = total(_x);
-                        if t < -1 * delta || t >= delta {
+                        if t < -delta || t >= delta {
                             break;
                         }
                         _x -= 1;
@@ -658,7 +658,7 @@ pub fn distance_line_to_point((x, y): Point, (a, b, c): Line) -> f64 {
 }
 
 pub fn perpendicular((a, b, c): Line, p: Point) -> Line {
-    (b, -1 * a, a * p.1 - b * p.0)
+    (b, -a, a * p.1 - b * p.0)
 }
 
 pub fn point_perpendicular((a, b, c): Line, p: Point) -> Point {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ impl Image {
             .name("b")
             .unwrap()
             .as_str()
-            .split(",")
+            .split(',')
             .map(|h| u8::from_str_radix(&h.trim()["0x".len()..], 16))
             .collect::<Result<Vec<u8>, _>>()?;
         Ok(Image {


### PR DESCRIPTION
Hello, I've fixed the clippy warnings for the library (there were a lot of 'em), with a separate commit for each lint, in order to facilitate review and picking & choosing.

In case you want more information on a specific lint you can check the clippy website, e.g.: https://rust-lang.github.io/rust-clippy/master/index.html#nonminimal_bool
